### PR TITLE
Integrate Auth0 login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_AUTH0_DOMAIN=your-auth0-domain
+VITE_AUTH0_CLIENT_ID=your-client-id

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
     "rxjs": "^7.8.1",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "@auth0/auth0-react": "^2.2.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^2.0.0",

--- a/src/renderer/src/components/auth/login-button.tsx
+++ b/src/renderer/src/components/auth/login-button.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@chakra-ui/react';
+import { useAuth0 } from '@auth0/auth0-react';
+
+function LoginButton(): JSX.Element | null {
+  const { loginWithRedirect, isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading || isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <Button onClick={() => loginWithRedirect()}>
+      Log In
+    </Button>
+  );
+}
+
+export default LoginButton;

--- a/src/renderer/src/components/auth/logout-button.tsx
+++ b/src/renderer/src/components/auth/logout-button.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@chakra-ui/react';
+import { useAuth0 } from '@auth0/auth0-react';
+
+function LogoutButton(): JSX.Element | null {
+  const { logout, isAuthenticated } = useAuth0();
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <Button onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}>
+      Log Out
+    </Button>
+  );
+}
+
+export default LogoutButton;

--- a/src/renderer/src/components/auth/profile.tsx
+++ b/src/renderer/src/components/auth/profile.tsx
@@ -1,0 +1,19 @@
+import { Avatar, Box, Text } from '@chakra-ui/react';
+import { useAuth0 } from '@auth0/auth0-react';
+
+function Profile(): JSX.Element | null {
+  const { user, isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading || !isAuthenticated || !user) {
+    return null;
+  }
+
+  return (
+    <Box display="flex" alignItems="center" gap={2} color="white">
+      <Avatar src={user.picture} name={user.name} size="sm" />
+      <Text>{user.name}</Text>
+    </Box>
+  );
+}
+
+export default Profile;

--- a/src/renderer/src/components/sidebar/sidebar.tsx
+++ b/src/renderer/src/components/sidebar/sidebar.tsx
@@ -11,6 +11,9 @@ import BottomTab from './bottom-tab';
 import HistoryDrawer from './history-drawer';
 import { useSidebar } from '@/hooks/sidebar/use-sidebar';
 import GroupDrawer from './group-drawer';
+import LoginButton from '../auth/login-button';
+import LogoutButton from '../auth/logout-button';
+import Profile from '../auth/profile';
 
 // Type definitions
 interface SidebarProps {
@@ -42,7 +45,7 @@ const ToggleButton = memo(({ isCollapsed, onToggle }: {
 ToggleButton.displayName = 'ToggleButton';
 
 const HeaderButtons = memo(({ onSettingsOpen, onNewHistory }: HeaderButtonsProps) => (
-  <Box display="flex" gap={1}>
+  <Box display="flex" gap={1} alignItems="center">
     <Button onClick={onSettingsOpen}>
       <FiSettings />
     </Button>
@@ -62,6 +65,9 @@ const HeaderButtons = memo(({ onSettingsOpen, onNewHistory }: HeaderButtonsProps
     <Button onClick={onNewHistory}>
       <FiPlus />
     </Button>
+    <Profile />
+    <LoginButton />
+    <LogoutButton />
   </Box>
 ));
 

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -5,3 +5,11 @@ interface Window {
     onModeChanged: (callback: (mode: string) => void) => void
   }
 }
+interface ImportMetaEnv {
+  readonly VITE_AUTH0_DOMAIN: string;
+  readonly VITE_AUTH0_CLIENT_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
 import './index.css';
 import App from './App';
 
@@ -11,7 +12,16 @@ console.warn = (...args) => {
 };
 
 if (typeof window !== 'undefined') {
+  const domain = import.meta.env.VITE_AUTH0_DOMAIN;
+  const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
+
   createRoot(document.getElementById('root')!).render(
-    <App />,
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      authorizationParams={{ redirect_uri: window.location.origin }}
+    >
+      <App />
+    </Auth0Provider>,
   );
 }


### PR DESCRIPTION
## Summary
- add Auth0 React dependency and .env example variables
- type definitions for Auth0 env vars
- wrap the renderer with `Auth0Provider`
- add simple login/logout/profile components
- show auth controls in the sidebar

## Testing
- `npm run lint` *(fails: couldn't find airbnb config)*
- `npm run typecheck` *(fails: cannot find module '@auth0/auth0-react')*


------
https://chatgpt.com/codex/tasks/task_e_683a16735580832bb2fff83199dfb1d2